### PR TITLE
fix detection of architecture (amd64)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -87,7 +87,7 @@ detect_arch() {
     error 'Unable to detect architecture'
     exit 1
   fi
-  if [ "$ARCH" = "x86_64"]; then
+  if [ "$ARCH" = "x86_64" ]; then
     ARCH='amd64'
   fi
 }


### PR DESCRIPTION
This PR fixes the issue that Linux x86_64 can not pull the right (amd64) binary.
Please take a look at it and merge it if everything is good.
